### PR TITLE
Fixed KeyError while setting file_sxcu with a .sxcu file of a public subdomain

### DIFF
--- a/sxcu/sxcu.py
+++ b/sxcu/sxcu.py
@@ -68,7 +68,10 @@ class SXCU:
                 con = json.load(sxcu_file)
             # requests url already contain `/upload` removing that.
             self.subdomain = "/".join(con["RequestURL"].split("/")[:-1])
-            self.upload_token = con["Arguments"]["token"]
+            
+            # If the subdomain is public it dont have "Arguments" in the .sxcu files
+            if "Arguments" in con.keys():
+                self.upload_token = con["Arguments"]["token"]
 
     def upload_image(
         self,


### PR DESCRIPTION
If a .sxcu file don't have `Arguments`  which causes a KeyError. 