### PR TITLE
Allow uploading file directly from `BytesIO`

### DIFF
--- a/sxcu/sxcu.py
+++ b/sxcu/sxcu.py
@@ -147,7 +147,7 @@ class SXCU:
             files = {"file": open(file, "rb")}
         res = request_handler.post(url, files=files, data=data)
         if not isinstance(file, io.BytesIO):
-            files['file'].close()
+            files["file"].close()
         if res.status_code != SXCU_SUCCESS_CODE:
             error_response = res.json()
             raise_error(

--- a/sxcu/sxcu.py
+++ b/sxcu/sxcu.py
@@ -100,7 +100,7 @@ class SXCU:
         og_properties: T.Optional[OGProperties] = None,
         self_destruct: bool = False,
         *,
-        file=None,
+        file: str = None,
     ) -> T.Union[dict, list]:
         """This uploads image to sxcu
 

--- a/sxcu/sxcu.py
+++ b/sxcu/sxcu.py
@@ -49,19 +49,23 @@ class SXCU:
         self.upload_token = upload_token  # Don't log upload_token
         self.file_sxcu = sxcu_config
         self.api_endpoint = DefaultDomains.API_ENDPOINT.value
-        if sxcu_config or file_sxcu:
-            if sxcu_config:
-                if isinstance(sxcu_config, io.StringIO):
-                    con = json.load(sxcu_config)
-                elif isinstance(sxcu_config, dict):
-                    con = sxcu_config
-                else:
-                    with open(sxcu_config) as sxcu_file:
-                        con = json.load(sxcu_file)
-            elif file_sxcu:
-                with open(file_sxcu) as sxcu_file:
+        if file_sxcu:
+            warnings.warn(
+                "file_sxcu parameter is deprecated. " "Use sxcu_config instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            sxcu_config = file_sxcu
+
+        if sxcu_config:
+            if isinstance(sxcu_config, io.StringIO):
+                con = json.load(sxcu_config)
+            elif isinstance(sxcu_config, dict):
+                con = sxcu_config
+            else:
+                with open(sxcu_config) as sxcu_file:
                     con = json.load(sxcu_file)
-            self.file_sxcu = con
+            self.sxcu_config = con
             # requests url already contain `/api/files/create` remove that.
             self.subdomain = "/".join(con["RequestURL"].split("/")[:-3])
             if "Arguments" in con:

--- a/sxcu/sxcu.py
+++ b/sxcu/sxcu.py
@@ -20,7 +20,7 @@ class SXCU:
     """The Main class for sxcu.net request"""
 
     def __init__(
-        self, subdomain: str = None, upload_token: str = None, sxcu_config: T.Union[str, io.StringIO] = None
+        self, subdomain: str = None, upload_token: str = None, sxcu_config: T.Union[str, dict, io.StringIO] = None
     ) -> None:
         """This initialise the handler
 
@@ -44,12 +44,12 @@ class SXCU:
         if sxcu_config:
             if isinstance(sxcu_config, io.StringIO):
                 con = json.load(sxcu_config)
+            elif isinstance(sxcu_config, dict):
+                con = sxcu_config
             else:
-                try:
-                    con = json.loads(sxcu_config)
-                except json.JSONDecodeError:
-                    with open(sxcu_config) as sxcu_file:
-                        con = json.load(sxcu_file)
+                with open(sxcu_config) as sxcu_file:
+                    con = json.load(sxcu_file)
+            self.sxcu_config = con
             # requests url already contain `/api/files/create` remove that.
             self.subdomain = "/".join(con["RequestURL"].split("/")[:-3])
             if "Arguments" in con:

--- a/sxcu/sxcu.py
+++ b/sxcu/sxcu.py
@@ -143,11 +143,11 @@ class SXCU:
         url = join_url(self._get_api_endpoint(default_domain=False), "/files/create")
         if isinstance(file, io.BytesIO):
             files = {"file": file}
-            res = request_handler.post(url, files=files, data=data)
         else:
-            with open(file, "rb") as img_file:
-                files = {"file": img_file}
-                res = request_handler.post(url, files=files, data=data)
+            files = {"file": open(file, "rb")}
+        res = request_handler.post(url, files=files, data=data)
+        if not isinstance(file, io.BytesIO):
+            files['file'].close()
         if res.status_code != SXCU_SUCCESS_CODE:
             error_response = res.json()
             raise_error(

--- a/sxcu/sxcu.py
+++ b/sxcu/sxcu.py
@@ -100,7 +100,7 @@ class SXCU:
         og_properties: T.Optional[OGProperties] = None,
         self_destruct: bool = False,
         *,
-        file = None,
+        file=None,
     ) -> T.Union[dict, list]:
         """This uploads image to sxcu
 
@@ -157,7 +157,7 @@ class SXCU:
         _file_opened = False
         try:
             if fileobj is None:
-                fileobj = open(name, 'rb')
+                fileobj = open(name, "rb")
                 _file_opened = True
             res = request_handler.post(url, files={"file": fileobj}, data=data)
         finally:

--- a/sxcu/sxcu.py
+++ b/sxcu/sxcu.py
@@ -20,7 +20,10 @@ class SXCU:
     """The Main class for sxcu.net request"""
 
     def __init__(
-        self, subdomain: str = None, upload_token: str = None, sxcu_config: T.Union[str, dict, io.StringIO] = None
+        self,
+        subdomain: str = None,
+        upload_token: str = None,
+        sxcu_config: T.Union[str, dict, io.StringIO] = None,
     ) -> None:
         """This initialise the handler
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import io
 import json
 import time
 from pathlib import Path
@@ -9,6 +10,7 @@ from sxcu import SXCU
 
 FILE_PATH = Path(__file__).parent
 IMG_LOC = Path(FILE_PATH, "assets", "sharex.png")
+IMG = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x01sRGB\x00\xae\xce\x1c\xe9\x00\x00\x00\x04gAMA\x00\x00\xb1\x8f\x0b\xfca\x05\x00\x00\x00\tpHYs\x00\x00\x0e\xc3\x00\x00\x0e\xc3\x01\xc7o\xa8d\x00\x00\x00\x0cIDAT\x18Wc\xf8\xff\xff?\x00\x05\xfe\x02\xfe\xa75\x81\x84\x00\x00\x00\x00IEND\xaeB`\x82"
 
 
 @pytest.mark.slow
@@ -34,6 +36,14 @@ def test_upload_image_default_domain() -> None:
 
     con = requests.get(con["url"])
     assert open(IMG_LOC, "rb") == con.content
+
+
+@pytest.mark.slow
+def test_upload_with_io_bytes():
+    _t = SXCU()
+    con = _t.upload_file(io.BytesIO(IMG), noembed=True)
+    file = requests.get(con["url"])
+    assert IMG == file.content
 
 
 # TODO: Test subdomains

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,7 +68,7 @@ def test_sxcu_file_parser() -> None:
 
     sxcu_file = Path(FILE_PATH, "assets", "sxcu.net - python.is-ne.at.sxcu")
     time.sleep(60)
-    _t = SXCU(file_sxcu=sxcu_file)
+    _t = SXCU(sxcu_config=sxcu_file)
     con = _t.upload_file(file=IMG_LOC, noembed=True)
 
     # test domain
@@ -84,7 +84,7 @@ def test_sxcu_file_parser_no_argument() -> None:
 
     sxcu_file = Path(FILE_PATH, "assets", "sxcu.net - why-am-i-he.re.sxcu")
     time.sleep(120)
-    t = SXCU(file_sxcu=sxcu_file)
+    t = SXCU(sxcu_config=sxcu_file)
     con = t.upload_file(file=IMG_LOC, noembed=True)
 
     # test domain
@@ -131,13 +131,13 @@ def test_create_link() -> None:
 
 def test_sxcu_file_init():
     sxcu_file = Path(FILE_PATH, "assets", "sxcu.net - why-am-i-he.re.sxcu")
-    _t = SXCU(file_sxcu=sxcu_file)
+    _t = SXCU(sxcu_config=sxcu_file)
     assert _t.subdomain == "https://why-am-i-he.re"
 
 
 def test_sxcu_file_init_with_token():
     sxcu_file = Path(FILE_PATH, "assets", "sxcu.net - python.is-ne.at.sxcu")
-    _t = SXCU(file_sxcu=sxcu_file)
+    _t = SXCU(sxcu_config=sxcu_file)
     assert _t.subdomain == "https://python.is-ne.at"
     assert _t.upload_token == "b8893b47-0e90-4fce-ad46-4264161a3a72"
 
@@ -180,6 +180,6 @@ def test_upload_mock(monkeypatch):
     monkeypatch.setattr(requests, "post", mock_get)
 
     sxcu_file = Path(FILE_PATH, "assets", "sxcu.net - python.is-ne.at.sxcu")
-    _t = SXCU(file_sxcu=sxcu_file)
+    _t = SXCU(sxcu_config=sxcu_file)
     a = _t.upload_file(IMG_LOC)
     assert json.dumps(a) == response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,7 +41,7 @@ def test_upload_image_default_domain() -> None:
 @pytest.mark.slow
 def test_upload_with_io_bytes():
     _t = SXCU()
-    con = _t.upload_file(io.BytesIO(IMG), noembed=True)
+    con = _t.upload_file(fileobj=io.BytesIO(IMG), noembed=True)
     file = requests.get(con["url"])
     assert IMG == file.content
 


### PR DESCRIPTION
#89 

The way it's set up right now is kind of awkward. I renamed `file_sxcu` to `sxcu_config` but you can revert that if you'd like. This name feels better to me but if you're worried about backwards compatibility it could break that.

the `file` param in `upload_file` now takes `str, bytes, io.BytesIO`. str is handled as a path and the two byte types are handled as file content.

`sxcu_config` in the initializer now takes `str, dict, io.StringIO`. `io.StringIO` is assumed to be valid json text, dict is handled like the already parsed json, and str is handled as a path once again.

I believe the user experience here is good as the user can either pass in the file's content or a path to the file in each example. If you have any issues with this lmk :)